### PR TITLE
Add caching implementation to synDownloader()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: synExtra
 Title: Extension of R Synapse Client
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: c(person("Artem", "Sokolov", email = "artem.sokolov@gmail.com", role = c("aut", "cre")),
     person("Clemens", "Hug", email = "clemens.hug@gmail.com", role = "aut"))
 Description: Features, extensions and UI modifications built on top of Sage Bionetworks' synapser.

--- a/man/synDownloader.Rd
+++ b/man/synDownloader.Rd
@@ -4,12 +4,16 @@
 \alias{synDownloader}
 \title{Instantiate a Synapse downloader}
 \usage{
-synDownloader(dloc, ...)
+synDownloader(dloc, ..., .cache = FALSE)
 }
 \arguments{
 \item{dloc}{Path to a local folder where downloaded files will be stored}
 
 \item{...}{Additional arguments to be passed to synapser::synGet()}
+
+\item{.cache}{Save files into directories inside dloc corresponding to their
+md5 hashes. Repeated requests for identical files will re-use already
+downloaded files}
 }
 \value{
 A downloader function that recognizes synapse IDs and downloads the associated files.


### PR DESCRIPTION
`synGet()` usually downloads files every time when the same synapse ID is requested multiple times. Multiple copies of the same file are downloaded and stored, wasting time and disk space.

This PR adds the `.cache` argument to `synDownloader()`. If set, it stores requested files in subdirectories of the given download location corresponding to the files' MD5 hashes. If a file is requested that is already cached the location of the cached file is returned instead of redownloading the file.